### PR TITLE
Add handling of mining drills using fluids

### DIFF
--- a/autodeconstruct.lua
+++ b/autodeconstruct.lua
@@ -141,18 +141,18 @@ function autodeconstruct.build_pipes(drill)
     local y = drill.position.y
     local dir = drill.direction
     -- create pipes for each fluid connector (ignore the side with the ore output)
-    game.surfaces[1].create_entity{name="entity-ghost", position = {x = x, y = y}, force=drill.last_user, inner_name="pipe"}
+    game.surfaces[1].create_entity{name="entity-ghost", position = {x = x, y = y}, force=game.players[1].force, inner_name="pipe"}
     if dir ~= 0 then
-        game.surfaces[1].create_entity{name="entity-ghost", position = {x = x, y = y-1}, force=drill.last_user, inner_name="pipe"}
+        game.surfaces[1].create_entity{name="entity-ghost", position = {x = x, y = y-1}, force=game.players[1].force, inner_name="pipe"}
     end
     if dir ~= 2 then
-        game.surfaces[1].create_entity{name="entity-ghost", position = {x = x + 1, y = y}, force=drill.last_user, inner_name="pipe"}
+        game.surfaces[1].create_entity{name="entity-ghost", position = {x = x + 1, y = y}, force=game.players[1].force, inner_name="pipe"}
     end
     if dir ~= 4 then
-        game.surfaces[1].create_entity{name="entity-ghost", position = {x = x, y = y + 1}, force=drill.last_user, inner_name="pipe"}
+        game.surfaces[1].create_entity{name="entity-ghost", position = {x = x, y = y + 1}, force=game.players[1].force, inner_name="pipe"}
     end
     if dir ~= 6 then
-        game.surfaces[1].create_entity{name="entity-ghost", position = {x = x - 1, y = y}, force=drill.last_user, inner_name="pipe"}
+        game.surfaces[1].create_entity{name="entity-ghost", position = {x = x - 1, y = y}, force=game.players[1].force, inner_name="pipe"}
     end
 end
 

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -7,4 +7,4 @@ autodeconstruct-debug=[autodeconstruct.__1__] Debug: __2__
 [mod-setting-name]
 autodeconstruct-remove-target=Also mark output chests for deconstruction
 autodeconstruct-remove-fluid-drills=Also remove drills using fluids
-autodeconstruct-build-pipes=Create Pipes when removing drills using fluids
+autodeconstruct-build-pipes=Create pipes when removing drills that are using fluids

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -6,3 +6,5 @@ autodeconstruct-debug=[autodeconstruct.__1__] Debug: __2__
 
 [mod-setting-name]
 autodeconstruct-remove-target=Also mark output chests for deconstruction
+autodeconstruct-remove-fluid-drills=Also remove drills using fluids
+autodeconstruct-build-pipes=Create Pipes when removing drills using fluids

--- a/settings.lua
+++ b/settings.lua
@@ -6,4 +6,18 @@ data:extend({
         default_value = true,
         order = "ad-a",
     },
+    {
+        type = "bool-setting",
+        name = "autodeconstruct-remove-fluid-drills",
+        setting_type = "runtime-global",
+        default_value = true,
+        order = "ad-b",
+    },
+    {
+        type = "bool-setting",
+        name = "autodeconstruct-build-pipes",
+        setting_type = "runtime-global",
+        default_value = true,
+        order = "ad-c",
+    },
 })


### PR DESCRIPTION
This change adds pipe-ghosts (to be constructed) at the location of fluid-using drills marked for deconstruction. This way it is also possible manage uranium and gold (etc.) mining with this mod, without breaking the fluid distribution.

_The force of the player building the pipes is hardcoded to `game.players[1].force`, this is suboptimal but works._

I initially created this for 0.1.12 and only tested with 0.1.14 for like 30s gametime... it doesn't crash but is not really tested. Please review my changes.