### PR TITLE
Can now also remove drills that are using fluids (updated code)

### DIFF
--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -6,3 +6,5 @@ autodeconstruct-debug=[autodeconstruct.__1__] Debug: __2__
 
 [mod-setting-name]
 autodeconstruct-remove-target=Also mark output chests for deconstruction
+autodeconstruct-remove-fluid-drills=Also remove drills that are using fluids
+autodeconstruct-build-pipes=Create pipes when removing drills that are using fluids

--- a/settings.lua
+++ b/settings.lua
@@ -6,4 +6,18 @@ data:extend({
     default_value = true,
     order = "ad-a",
   },
+  {
+    type = "bool-setting",
+    name = "autodeconstruct-remove-fluid-drills",
+    setting_type = "runtime-global",
+    default_value = true,
+    order = "ad-b",
+  },
+  {
+    type = "bool-setting",
+    name = "autodeconstruct-build-pipes",
+    setting_type = "runtime-global",
+    default_value = true,
+    order = "ad-c",
+  },
 })


### PR DESCRIPTION
Can now create pipe-ghosts when removing drills that are using fluids.

- Same feature as previously, just based on the most recent revision.
- improved handling of force and surface as requested in the last PR's review
- Pipes are still "just" a static T-shape. Considering the low cost of pipes, I prefer to keep the mod code simple.