### PR TITLE
Compatiblilty with larger drills

### DIFF
--- a/autodeconstruct.lua
+++ b/autodeconstruct.lua
@@ -19,18 +19,19 @@ local function find_resources(surface, position, range, resource_category)
 end
 
 local function find_all_entities(entity_type)
-  local surface = game.surfaces['nauvis']
   local entities = {}
-
-  for chunk in surface.get_chunks() do
-    local chunk_area = {lefttop = {x = chunk.x*32, y = chunk.y*32}, rightbottom = {x = chunk.x*32+32, y = chunk.y*32+32}}
-    local chunk_entities = surface.find_entities_filtered({area = chunk_area, type = entity_type})
-
-    for i = 1, #chunk_entities do
-      entities[#entities + 1] = chunk_entities[i]
+  for _, surface in pairs(game.surfaces) do
+    if not surface or not surface.valid then
+      break
+    end
+    for chunk in surface.get_chunks() do
+      local chunk_area = {lefttop = {x = chunk.x*32, y = chunk.y*32}, rightbottom = {x = chunk.x*32+32, y = chunk.y*32+32}}
+      local chunk_entities = surface.find_entities_filtered({area = chunk_area, type = entity_type})
+      for i = 1, #chunk_entities do
+        entities[#entities + 1] = chunk_entities[i]
+      end
     end
   end
-
   return entities
 end
 

--- a/autodeconstruct.lua
+++ b/autodeconstruct.lua
@@ -21,14 +21,13 @@ end
 local function find_all_entities(entity_type)
   local entities = {}
   for _, surface in pairs(game.surfaces) do
-    if not surface or not surface.valid then
-      break
-    end
-    for chunk in surface.get_chunks() do
-      local chunk_area = {lefttop = {x = chunk.x*32, y = chunk.y*32}, rightbottom = {x = chunk.x*32+32, y = chunk.y*32+32}}
-      local chunk_entities = surface.find_entities_filtered({area = chunk_area, type = entity_type})
-      for i = 1, #chunk_entities do
-        entities[#entities + 1] = chunk_entities[i]
+    if surface and surface.valid then
+      for chunk in surface.get_chunks() do
+        local chunk_area = {lefttop = {x = chunk.x*32, y = chunk.y*32}, rightbottom = {x = chunk.x*32+32, y = chunk.y*32+32}}
+        local chunk_entities = surface.find_entities_filtered({area = chunk_area, type = entity_type})
+        for i = 1, #chunk_entities do
+          entities[#entities + 1] = chunk_entities[i]
+        end
       end
     end
   end


### PR DESCRIPTION
Based on the report at the mods [portal](https://mods.factorio.com/mod/AutoDeconstruct/discussion/60bc3b2fb2019f49b6a17e26 ), I have modified the pipe building to be based on the fluid box prototype instead being hardcoded.

I have done a couple of tests with the bigger AAI drills and it seems to be working fine. Unfortunately nobody in the mod portal forums offered test-feedback.

While I like the general structure of the new logic there are two places where I am unsure:
**1.**
`local fluidbox_prototype = drill.fluidbox.get_prototype(1)` is this the way to get the correct fluid box, or would using `game.entity_prototypes[drill.name]` (and then go to the members) be more correct...
**2.**
`autodeconstruct.build_pipe(drillData, pipeType, conn.positions[1])`
... why has the fluidbox prototype an array for each connection even though the drill was only created with a single location for the connection. This seems strange but works...

I'll just open it as a pull request for now, maybe you can also have a look.

*A pre-realease test package (zip) is available at https://github.com/nicolas-lang/AutoDeconstruct/releases*

P.S. ( I was busy and the invite timed out)