### PR TITLE
Add option to remove drills connected to wire

### DIFF
--- a/autodeconstruct.lua
+++ b/autodeconstruct.lua
@@ -480,10 +480,12 @@ function autodeconstruct.order_deconstruction(drill)
     end
   end
 
-  if next(drill.circuit_connected_entities.red) ~= nil or next(drill.circuit_connected_entities.green) ~= nil then
-    debug_message_with_position(drill, "is hooked up to the circuit network, skipping")
+  if not settings.global['autodeconstruct-remove-wired'].value then
+    if next(drill.circuit_connected_entities.red) ~= nil or next(drill.circuit_connected_entities.green) ~= nil then
+      debug_message_with_position(drill, "is hooked up to the circuit network and wire deconstruction is not enabled, skipping")
 
-    return
+      return
+    end
   end
 
   if not drill.minable then

--- a/control.lua
+++ b/control.lua
@@ -41,8 +41,10 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
     if not autodeconstruct.is_valid_pipe(settings.global[event.setting].value) then
       msg_all({"autodeconstruct-err-pipe-name", settings.global[event.setting].value})
     end
-  elseif (event.setting == "autodeconstruct-remove-fluid-drills" and
-      settings.global['autodeconstruct-remove-fluid-drills'].value == true) then
+  elseif ((event.setting == "autodeconstruct-remove-fluid-drills" and
+      settings.global['autodeconstruct-remove-fluid-drills'].value == true) or 
+      (event.setting == "autodeconstruct-remove-wired" and
+      settings.global['autodeconstruct-remove-wired'].value == true)) then
     local _, err = pcall(autodeconstruct.init_globals)
     if err then msg_all({"autodeconstruct-err-generic", err}) end
   end

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -8,6 +8,7 @@ autodeconstruct-debug=[autodeconstruct.__1__] Debug: __2__
 [mod-setting-name]
 autodeconstruct-remove-target=Also mark output chests for deconstruction
 autodeconstruct-remove-fluid-drills=Also remove drills that are using fluids
+autodeconstruct-remove-wired=Also remove drills that are connected to a circut network
 autodeconstruct-build-pipes=Create pipes when removing drills that are using fluids
 autodeconstruct-pipe-name=Type of pipe to build when removing drills
 autodeconstruct-space-pipe-name=Type of pipe to build when removing drills in space

--- a/settings.lua
+++ b/settings.lua
@@ -15,6 +15,13 @@ data:extend({
   },
   {
     type = "bool-setting",
+    name = "autodeconstruct-remove-wired",
+    setting_type = "runtime-global",
+    default_value = false,
+    order = "ad-ab",
+  },
+  {
+    type = "bool-setting",
     name = "autodeconstruct-remove-fluid-drills",
     setting_type = "runtime-global",
     default_value = true,


### PR DESCRIPTION
Currently the mod prevents drills attached to a circuit from being marked for deconstruction. I would like an option to allow them to be. The new option defaults to off to prevent breaking existing circuits. 

An example use case for the option is mines tracking the resources by wire to send alerts. Each drill is a connected to a wire, but can be removed at anytime. 