### PR TITLE
Update translation base.cfg by automatic system 

### DIFF
--- a/locale/pt-BR/base.cfg
+++ b/locale/pt-BR/base.cfg
@@ -1,16 +1,19 @@
 autodeconstruct-err-generic=[autodeconstruct] Erro: __1__
 autodeconstruct-err-specific=[autodeconstruct|__1__] Erro: __2__
-autodeconstruct-err-pipe-name=[autodeconstruct] Erro: configuração inválida. Não é possível encontrar o pipe com o nome __1__.
+autodeconstruct-err-pipe-name=[autodeconstruct] Erro: Configuração inválida. Não foi possível encontrar o cano com o nome "__1__".
 
 autodeconstruct-notify=[autodeconstruct] Notificação: __1__
-autodeconstruct-debug=[autodeconstruct.__1__] Debug: __2__
+autodeconstruct-debug=[autodeconstruct.__1__] Depurar: __2__
 
 [mod-setting-name]
-autodeconstruct-remove-target=Também marcar baús de saída para desconstrução
-autodeconstruct-remove-fluid-drills=Também remova mineradoras que estão usando fluidos
-autodeconstruct-build-pipes=Crie canos ao remover mineradoras que estão usando fluidos
-autodeconstruct-pipe-name=Tubo a ser construído ao remover mineradoras
-autodeconstruct-space-pipe-name=Tubo a ser construído ao remover mineradoras no espaço
-autodeconstruct-preserve-inserter-chains=Não remova as mineradoras com os insersores extraindo combustível delas
+autodeconstruct-remove-target=Marque também os baús de saída para desconstrução.
+autodeconstruct-remove-fluid-drills=Remova também as mineradoras que utilizam fluidos
+autodeconstruct-remove-wired=Remova também as mineradoras conectadas a uma rede de circuitos
+autodeconstruct-build-pipes=Criar canos ao remover mineradoras que utilizam fluidos
+autodeconstruct-pipe-name=Tipo de cano a ser construído ao remover mineradoras
+autodeconstruct-space-pipe-name=Tipo de cano a ser construído ao remover mineradoras no espaço
+autodeconstruct-preserve-inserter-chains=Não remova mineradoras com insersores que extraem combustível delas
+autodeconstruct-blacklist=mineradoras e baús para NÃO remover automaticamente
 
-
+[mod-setting-description]
+autodeconstruct-blacklist=Separe vários nomes de protótipos de entidades usando espaço, vírgula ou ponto e vírgula.


### PR DESCRIPTION
updated all itens,blocs,descriptions
```makefile
autodeconstruct-err-generic=[autodeconstruct] Erro: __1__
autodeconstruct-err-specific=[autodeconstruct|__1__] Erro: __2__
autodeconstruct-err-pipe-name=[autodeconstruct] Erro: Configuração inválida. Não foi possível encontrar o cano com o nome "__1__".

autodeconstruct-notify=[autodeconstruct] Notificação: __1__
autodeconstruct-debug=[autodeconstruct.__1__] Depurar: __2__

[mod-setting-name]
autodeconstruct-remove-target=Marque também os baús de saída para desconstrução.
autodeconstruct-remove-fluid-drills=Remova também as mineradoras que utilizam fluidos
autodeconstruct-remove-wired=Remova também as mineradoras conectadas a uma rede de circuitos
autodeconstruct-build-pipes=Criar canos ao remover mineradoras que utilizam fluidos
autodeconstruct-pipe-name=Tipo de cano a ser construído ao remover mineradoras
autodeconstruct-space-pipe-name=Tipo de cano a ser construído ao remover mineradoras no espaço
autodeconstruct-preserve-inserter-chains=Não remova mineradoras com insersores que extraem combustível delas
autodeconstruct-blacklist=mineradoras e baús para NÃO remover automaticamente

[mod-setting-description]
autodeconstruct-blacklist=Separe vários nomes de protótipos de entidades usando espaço, vírgula ou ponto e vírgula.
``` 